### PR TITLE
Added the ability to specify includeTags and excludeTags, and supply testing parameters to Pester Tests

### DIFF
--- a/Xpirit-Vsts-Build-Pester/Pester.ps1
+++ b/Xpirit-Vsts-Build-Pester/Pester.ps1
@@ -1,9 +1,12 @@
     Param(
     [string] $ItemSpec = "*.tests.ps1",
+	[string] $IncludeTags,
+	[string] $ExcludeTags,
     [string] $FailOnError = "false"
 )
 
-$WorkingDirectory = $env:BUILD_SOURCESDIRECTORY
+$WorkingDirectory = "C:\Users\kevbo\source\repos\pestertest"
+#$WorkingDirectory = $env:BUILD_SOURCESDIRECTORY
 if (!$WorkingDirectory){
     $WorkingDirectory = $env:SYSTEM_DEFAULTWORKINGDIRECTORY
 }
@@ -48,8 +51,26 @@ Write-Output "Test files found:"
 Write-Output $TestFiles
 Write-Output "Writing pester output: $outputfile"
 
-Write-Output "Invoke-Pester $TestFiles -PassThru -Outputformat nunitxml -Outputfile $outputFile"
-$result = Invoke-Pester $TestFiles -PassThru -Outputformat nunitxml -Outputfile $outputFile    
+$Parameters = @{
+    Path = $TestFiles
+	Outputfile = $outputFile
+	Outputformat = "nunitxml"
+}
+
+if ($IncludeTags) {
+    $IncludeTags = $IncludeTags.Split(',').Replace('"', '').Replace("'", "")
+    $Parameters.Add('Tag', $IncludeTags)
+    Write-Output "Tags included: $IncludeTags"
+}
+
+if ($ExcludeTags) {
+    $ExcludeTags = $ExcludeTags.Split(',').Replace('"', '').Replace("'", "")
+    $Parameters.Add('ExcludeTag', $ExcludeTags)
+    Write-Output "Tags excluded: $ExcludeTags"
+}
+
+Write-Output "Invoke-Pester @Parameters -PassThru"
+$result = Invoke-Pester @Parameters -PassThru
 
 if ([boolean]::Parse($FailOnError)){
     if ($result.failedCount -ne 0)

--- a/Xpirit-Vsts-Build-Pester/task.json
+++ b/Xpirit-Vsts-Build-Pester/task.json
@@ -9,8 +9,8 @@
   "author": "Peter Groenewegen - Xpirit",
   "version": {
     "Major": 2,
-    "Minor": 2,
-    "Patch": 1
+    "Minor": 3,
+    "Patch": 0
   },
   "demands": [ ],
   "minimumAgentVersion": "1.90.0",
@@ -30,7 +30,7 @@
       "label": "Testing Parameters",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Pass a hashtable of paramters required by Pester scripts"
+      "helpMarkDown": "Pass a comma separated list of paramters required by Pester scripts.  Example: SqlAzureRegion = 'westeurope',DbAzureRegion = 'West Europe'  "
     },
     {
       "name": "IncludeTags",

--- a/Xpirit-Vsts-Build-Pester/task.json
+++ b/Xpirit-Vsts-Build-Pester/task.json
@@ -25,6 +25,30 @@
       "helpMarkDown": "*.tests.ps1 will get all your tests."
     },
     {
+      "name": "TestParams",
+      "type": "string",
+      "label": "Testing Parameters",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Pass a hashtable of paramters required by Pester scripts"
+    },
+    {
+      "name": "IncludeTags",
+      "type": "string",
+      "label": "Include Tags",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Supply tags in comma separated list.  Avoid spaces in tag"
+    },
+    {
+      "name": "ExcludeTags",
+      "type": "string",
+      "label": "Exclude Tags",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Supply tags in comma separated list.  Avoid spaces in tag"
+    },
+    {
       "name": "FailOnError",
       "type": "boolean",
       "label": "Fail build on error",

--- a/extension-manifest.json
+++ b/extension-manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "PeterGroenewegen-Xpirit-Vsts-Build-Pester",
   "name": "Pester unittest build task",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "publisher": "petergroenewegen",
   "public": true,
   "targets": [


### PR DESCRIPTION
Hi, please take a look at this.  I've only been able to test the powershell locally like this:

```
$ResourceGroupName = 'demosqldb-rgp'
$SqlServerName = 'demosqldb-sql'

$override = "SqlAzureRegion = 'westeurope',DbAzureRegion = 'West Europe',ResourceGroupName=$ResourceGroupName, SqlServerName=$SqlServerName,SqlDatabase = 'demosqldb-db'"

C:\Users\kevbo\source\repos\Xpirit-Vsts-Build-Pester\Xpirit-Vsts-Build-Pester/Pester.ps1 -Itemspec *.tests.ps1 -TestParameters $override -IncludeTags "SQL,ARM" -FailOnError true
```

I have used multiple pester files with a variation of tags and describe blocks.  I've also tested that you can pass in a superset of the parameters needed for each test file.

I'm not familiar with building VSTS extensions in any detail, hence have not deployed to VSTS for proper testing.

This should close issues #4  and #5 